### PR TITLE
fix: 가게 이미지 없을 경우 빈 문자열로 반환

### DIFF
--- a/src/business/restaurant/repository/RestaurantQuery.ts
+++ b/src/business/restaurant/repository/RestaurantQuery.ts
@@ -5,7 +5,7 @@ export const restaurantQuery = {
     SELECT 
       r.id,
       IF(ri.imageName IS NULL,
-        CONCAT('${IMAGE_FILE_PATH.RESTAURANT}', '${IMAGE_FILE_PATH.DEFAULT}'),
+        '',
         CONCAT('${IMAGE_FILE_PATH.RESTAURANT}', ri.imageName)) AS restaurantThumbnail,
       r.restaurantName,
       r.restaurantType,


### PR DESCRIPTION
##  의도

- 가게의 이미지가 없을 경우 프론트에서 정적인 기본이미지를 노출하기로 기획수정


<br>

##  주요 변경사항

- 가게 이미지 없을 경우 빈 문자열로 반환 


<br>

##  To Reviewers

-


<br>
